### PR TITLE
try to avoid encoding as json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         id: action-run
         continue-on-error: true
         with:
-          environment-paths: "${{ toJSON(matrix.env-paths) }}"
+          environment-paths: ${{ matrix.env-paths }}
       - name: detect outcome
         if: always()
         shell: bash -l {0}

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: >-
       The paths to the environment files
     required: True
-    type: string
+    type: list
 outputs: {}
 
 runs:
@@ -23,4 +23,4 @@ runs:
         COLUMNS: 120
         FORCE_COLOR: 3
       run: |
-        python minimum_versions.py ${{ join(fromJSON(inputs.environment-paths), ' ') }}
+        python minimum_versions.py ${{ join(inputs.environment-paths, ' ') }}


### PR DESCRIPTION
The action currently seems to require encoding the input list as json, since github actions doesn't support passing lists to actions.

One of the workarounds is encoding as json, but I don't think this is a particularly user-friendly option. Another is splitting by line-breaks, so if this doesn't work we can use that as a fall-back.