### PR TITLE
use github.action_path for requirements.txt

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: install dependencies
       shell: bash -l {0}
       run: |
-        python -m pip install -r requirements.txt
+        python -m pip install -r ${{ github.action_path }}/requirements.txt
     - name: analyze environments
       shell: bash -l {0}
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -24,4 +24,4 @@ runs:
         FORCE_COLOR: 3
         INPUT: ${{ inputs.environment-paths }}
       run: |
-        python minimum_versions.py $(echo $INPUT)
+        python ${{ github.action_path }}/minimum_versions.py $(echo $INPUT)


### PR DESCRIPTION
Finally came around to test this (regionmask/regionmask#587), however, it currently fails ([actions-run](https://github.com/regionmask/regionmask/actions/runs/12133516903/job/33829187745?pr=587)) with `ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'`

If I understand the [docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runsstepsrun) correctly we can use `${{ github.action_path }}/requirements.txt` to fix this.