### PR TITLE
avoid raising if `x.y.0` does not exist

### DIFF
--- a/envs/env2.yaml
+++ b/envs/env2.yaml
@@ -7,3 +7,4 @@ dependencies:
   - dask=2023.10.0
   - distributed=2023.10.0
   - pydap=3.5.1
+  - netcdf4=1.7

--- a/minimum_versions.py
+++ b/minimum_versions.py
@@ -230,7 +230,15 @@ def is_suitable_release(release):
 def lookup_spec_release(spec, releases):
     version = spec.version.extend_to_length(3)
 
-    return releases[spec.name][version]
+    compatible_versions = [
+        release
+        for v, release in releases[spec.name].items()
+        if v.compatible_with(version)
+    ]
+    if not compatible_versions:
+        return Release(version="", build_number=0, timestamp=datetime.date(1970, 1, 1))
+
+    return compatible_versions[0]
 
 
 def compare_versions(environments, policy_versions, ignored_violations):


### PR DESCRIPTION
- [x] closes #18

For now, we'll fall back to the next in line, and print 1970-01-01 as date if
there's no compatible version whatsoever.