### PR TITLE
document empty `overrides`, `exclude` and `ignored_validations`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,20 @@ jobs:
             envs/env1.yaml
             envs/env2.yaml
         expected-failure: ["false"]
+        policy-file: ["policy.yaml"]
         include:
           - env-paths: |
               envs/failing-env1.yaml
+            policy-file: "policy.yaml"
             expected-failure: "true"
           - env-paths: |
               envs/env1.yaml
               envs/failing-env1.yaml
+            policy-file: "policy.yaml"
             expected-failure: "true"
+          - env-paths: "envs/env1.yaml"
+            policy-file: policy_no_extra_options.yaml
+            expected-failure: "false"
 
     steps:
       - name: clone the repository
@@ -67,7 +73,7 @@ jobs:
         id: action-run
         continue-on-error: true
         with:
-          policy: policy.yaml
+          policy: ${{ matrix.policy-file }}
           environment-paths: ${{ matrix.env-paths }}
           today: 2024-12-20
       - name: detect outcome

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ policy:
     - package4
 ```
 
+if there are no packages with `overrides`, `exclude`, or `ignored_violations`, you can set
+them to an empty dictionary or list, respectively:
+
+```yaml
+  ...
+  overrides: {}
+  exclude: []
+  ignored_violations: []
+```
+
 then add a new step to CI:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ policy:
     - package4
 ```
 
-if there are no packages with `overrides`, `exclude`, or `ignored_violations`, you can set
-them to an empty dictionary or list, respectively:
+If there are no packages with `overrides`, `exclude`, or `ignored_violations`, you can set
+them to an empty mapping or sequence, respectively:
 
 ```yaml
   ...
@@ -42,7 +42,7 @@ them to an empty dictionary or list, respectively:
   ignored_violations: []
 ```
 
-then add a new step to CI:
+Then add a new step to CI:
 
 ```yaml
 jobs:

--- a/policy_no_extra_options.yaml
+++ b/policy_no_extra_options.yaml
@@ -1,0 +1,14 @@
+channels:
+  - conda-forge
+platforms:
+  - noarch
+  - linux-64
+policy:
+  # all packages in months
+  packages:
+    python: 30
+    numpy: 18
+  default: 12
+  overrides: {}
+  exclude: []
+  ignored_violations: []


### PR DESCRIPTION
Documents how empty `overrides`, `exclude`, and `ignored_validations` can be set. Supersedes #32.