### PR TITLE
widen package regex

### DIFF
--- a/minimum_versions.py
+++ b/minimum_versions.py
@@ -31,7 +31,7 @@ schema = {
                 "packages": {
                     "type": "object",
                     "patternProperties": {
-                        "^[a-z][a-z0-9_]*$": {"type": "integer", "minimum": 1}
+                        "^[a-z][a-z0-9_-]*$": {"type": "integer", "minimum": 1}
                     },
                     "additionalProperties": False,
                 },


### PR DESCRIPTION
Currently _netcdf4_ fails the regex check.

I am not sure about uppercase names. They are discouraged (disallowed?) by PEP8 but allowed on pypi (e.g. https://pypi.org/project/D47calib/) but maybe not on conda?