### PR TITLE
support excluding versions for excluded packages

### DIFF
--- a/envs/pixi.toml
+++ b/envs/pixi.toml
@@ -11,7 +11,11 @@ python = "3.10"
 [feature.failing.dependencies]
 numpy = "2.1"
 
+[feature.exclude.dependencies]
+pytest = "!=9.1.0"
+
 [environments]
 env1 = { features = ["py310"] }
 env2 = ["py39"]
 failing-env = { features = ["failing"] }
+exclude-env = { features = ["exclude"] }

--- a/minimum_versions/environments/pixi.py
+++ b/minimum_versions/environments/pixi.py
@@ -118,7 +118,7 @@ def parse_pixi_environment(name: str, manifest_path: pathlib.Path | None):
         (
             get_in([feature, "dependencies"], all_features, {})
             if feature != "default"
-            else pixi_config.get("dependencies", [])
+            else pixi_config.get("dependencies", {})
         )
         for feature in feature_names
     ]

--- a/minimum_versions/environments/pixi.py
+++ b/minimum_versions/environments/pixi.py
@@ -11,6 +11,7 @@ _version_re = r"[0-9]+\.[0-9]+(?:\.[0-9]+|\.\*)?"
 version_re = re.compile(f"(?P<version>{_version_re})")
 lower_pin_re = re.compile(rf">=(?P<version>{_version_re})$")
 tight_pin_re = re.compile(rf">=(?P<lower>{_version_re}),<(?P<upper>{_version_re})")
+exclusion_pin_re = re.compile(rf"!=(?P<excluded>{_version_re})$")
 
 
 def parse_spec(name, version_text: str | dict):
@@ -44,6 +45,13 @@ def parse_spec(name, version_text: str | dict):
         )
 
         raw_version = lower_pin
+    elif (match := exclusion_pin_re.match(version_text)) is not None:
+        excluded = match.group("excluded")
+        warnings.append(
+            f"Excluded version found: {excluded!r}. This is invalid for policy packages"
+            " and must be ignored explicitly."
+        )
+        raw_version = excluded
     else:
         raise ValueError(f"Unsupported version spec: {version_text}")
 

--- a/minimum_versions/main.py
+++ b/minimum_versions/main.py
@@ -61,7 +61,8 @@ def validate(today, policy_file, manifest_path, environment_paths):
     }
 
     warnings = {
-        env: dict(warnings_) for env, (_, warnings_) in parsed_environments.items()
+        env: {n: w for n, w in warnings_ if n not in policy.exclude}
+        for env, (_, warnings_) in parsed_environments.items()
     }
     environments = {
         env: [spec for spec in specs if spec.name not in policy.exclude]

--- a/minimum_versions/tests/test_environments.py
+++ b/minimum_versions/tests/test_environments.py
@@ -357,6 +357,32 @@ class TestPixiEnvironment:
                 [("c", [])],
                 id="local_package",
             ),
+            pytest.param(
+                textwrap.dedent("""\
+                    [feature.feature1.dependencies]
+                    a = "!=1.0.1"
+
+                    [environments]
+                    env1 = { features = ["feature1"] }
+                    """.rstrip()),
+                "pixi.toml",
+                [
+                    Spec("a", Version("1.0.1")),
+                ],
+                [
+                    (
+                        "a",
+                        [
+                            (
+                                "Excluded version found: '1.0.1'. This is invalid for policy packages"
+                                " and must be ignored explicitly."
+                            ),
+                            "package should be pinned to a minor version (got 1.0.1)",
+                        ],
+                    )
+                ],
+                id="excluded_version",
+            ),
         ),
     )
     def test_parse_pixi_environment(


### PR DESCRIPTION
Basically, if we exclude `pytest` from the policy, `pytest!=9.1.0` is allowed.